### PR TITLE
return CSP_ERR_TX instead of CSP_ERR_NOTSUP

### DIFF
--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -396,7 +396,7 @@ int csp_sendto(uint8_t prio, uint16_t dest, uint8_t dport, uint8_t src_port, uin
 	packet->id.pri = prio;
 
 	if (csp_send_direct(packet->id, packet, csp_rtable_find_route(dest), timeout) != CSP_ERR_NONE)
-		return CSP_ERR_NOTSUP;
+		return CSP_ERR_TX;
 	
 	return CSP_ERR_NONE;
 


### PR DESCRIPTION
What I mentioned last week about the one-liner PR.
I've checked that it is not used anywhere else in the code, but comments on how to merge such small diffs are welcome.
